### PR TITLE
Update boostings.ride

### DIFF
--- a/boostings.ride
+++ b/boostings.ride
@@ -1,16 +1,17 @@
 {-# STDLIB_VERSION 6 #-}
 {-# SCRIPT_TYPE ACCOUNT #-}
 {-# CONTENT_TYPE DAPP #-}
+{-# IMPORT artifacts/testnet.ride #-}
 
 let li = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "55", "56"] #, "57", "58", "59", "60", "61", "62", "63", "65", "66", "67", "68", "69", "70", "71", "72", "73", "75", "76", "77", "78", "79", "80", "81", "82", "83", "85", "86", "87", "88"] #, "89", "90", "91", "92", "93", "95", "96", "97", "98", "99", "100"]
 
 #test mode 10 minutes per day
-# let hours = 1
-# let minutes = 10
+ let hours = 1
+ let minutes = 10
 
 #regular mode
-let hours = 24
-let minutes = 60
+#let hours = 24
+#let minutes = 60
 
 func tryGetInteger (key:String) = match getInteger(this, key) {
     case b: Int => 
@@ -46,11 +47,27 @@ func payBoostingResult (boostingId:String) = {
         then {
             let blockReward = tryGetInteger((("boosting_" + boostingId) + "_totalAmount")) / ((tryGetInteger(("boosting_" + boostingId) + "_days") * hours * minutes))
             let toPay = fraction((min([finishHeight, height]) - lastHeight), blockReward, 1)
+
+            let getFinishedPoolId = tryGetString((("boosting_" + boostingId) + "_poolId"))
+            let getPoolBoostings =  tryGetString(("pool_" + getFinishedPoolId) + "_boostings")
+            let sizeStr = size(getPoolBoostings)
+            let findIndex = value(indexOf(getPoolBoostings, boostingId))
+            let modifierLeft = if findIndex == 0 then 0 else 1
+            let modifierRight = if findIndex == 0 then 2 else 1
+            let leftStr = take(getPoolBoostings, sizeStr - (sizeStr - findIndex + modifierLeft))
+            let rightStr = takeRight(getPoolBoostings, sizeStr - (findIndex + modifierRight))
+            let openBoostingsIds = leftStr + rightStr            
             [
             IntegerEntry((("boosting_" + boostingId) + "_lastHeight"), height), 
+
             ScriptTransfer(addressFromStringValue(tryGetString((("boosting_" + boostingId) + "_poolId"))), 
-                toPay, 
-                getAssetBytes(tryGetString((("boosting_" + boostingId) + "_assetId"))))
+              toPay, 
+              getAssetBytes(tryGetString((("boosting_" + boostingId) + "_assetId")))),
+
+            StringEntry((("pool_" + getFinishedPoolId) + "_boostings"),
+              if (height < finishHeight) 
+              then tryGetString((("pool_" + getFinishedPoolId) + "_boostings")) 
+              else openBoostingsIds)
             ]
             }
         else nil
@@ -61,7 +78,7 @@ func endedBoostingIds (boostingId:String) = {
     let finishHeight = tryGetInteger((("boosting_" + boostingId) + "_finishHeight"))
     if finishHeight <= lastHeight then 
     [StringEntry((("list ended " + toString(height)) + " boostingIds"), ((tryGetString((("list ended " + toString(height)) + " boostingIds")) + boostingId) + ","))]
-        else nil
+        else [StringEntry((("list ongoing boosts " + toString(height)) + " boostingIds"), ((tryGetString((("list ongoing boosts " + toString(height)) + " boostingIds")) + boostingId) + ","))]
     }
 
 @Callable(i)
@@ -69,14 +86,14 @@ func addBoosting (poolId:String, days:Int) =
 if (days < 1) then throw("amount of days has to be between 1 and 365") else if (days> 365) then throw("amount of days has to be between 1 and 365") else
 #protected mode, to comment out after succesfull live testing 
 if (false) then throw("under maintenance until further notice") else # i.caller != Address(base58'3P8qVX189qpoTJZQQQdKS9endHK5sxWsvrd'))
+
 {
     let fullAmount = i.payments[0].amount
     if fullAmount / days < 1440 then throw((("boosting amount too small, minimum is " + toString((1440 * days)) + " of the smallest unit of payment asset"))) else
         let assetId = getAssetString(i.payments[0].assetId)
         if height == tryGetInteger("height") then throw("wait 1 minute") else
-    strict entry = invoke(this, "entryEnded", [], [])
-    strict get = invoke(this, "firstEndedBoostingId", [], [])
-    let boostingId = toString(tryGetInteger("first"))
+    strict entry = if size(tryGetString(("pool_" + poolId) + "_boostings")) > 11 then throw("max 5 boosts per pool") else invoke(this, "entryEnded", [], [])
+    let boostingId = if size(("list ongoing boosts " + toString(height)) + " boostingIds") > 112 then throw("wait till other boosts are finished") else take(tryGetString(("list ended " + toString(height)) + " boostingIds"), 1)
     if ((addressFromString(poolId) == unit))
         then throw("incorrect pool address")
         else 
@@ -134,14 +151,3 @@ func entryEnded () = {
         then [IntegerEntry("height", height)]
         else throw("Strict value is not equal to itself.")
     }
-
-@Callable(i)
-func firstEndedBoostingId () = {
-    func fold(accum: List[Int], next: String) = {
-    accum :+ next.parseIntValue()
-    }
-        let StringValue = dropRight(tryGetString(("list ended " + toString(height)) + " boostingIds"), 1)
-        let list = FOLD<56>(StringValue.split_4C(","), [], fold)
-        let firstOfList = getElement(list, 0)
-        [IntegerEntry("first", firstOfList)]
-}


### PR DESCRIPTION
1. simplified firstEndedBoostingId to take(String, 1) in local function, functionality unchanged
2. limited max boosts 56
3. limit max boosts per pool 5
4. remove finished boosts from data
5. Still to change: comment the test speed, days and hours
6. tests: https://wavesexplorer.com/addresses/3N3y7nQfqDc7rBUExjKQi5ZbspWRh9q8PYH?network=testnet&search=3N3y7nQfqDc7rBUExjKQi5ZbspWRh9q8PYH